### PR TITLE
Update Person Added & Removed from Tenure logic

### DIFF
--- a/CautionaryAlertsListener.Tests/E2ETests/Fixtures/CautionaryAlertFixture.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Fixtures/CautionaryAlertFixture.cs
@@ -53,7 +53,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
 
         public void GivenTheCautionaryAlertAlreadyExist(Guid mmhId, string propertyReference = null)
         {
-            if (null == DbEntity)
+            if (DbEntity == null)
             {
                 var entity = ConstructAndSaveCautionaryAlertMMHIDOptionalPropertyReference(mmhId, propertyReference);
                 DbEntity = entity;

--- a/CautionaryAlertsListener.Tests/E2ETests/Fixtures/CautionaryAlertFixture.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Fixtures/CautionaryAlertFixture.cs
@@ -2,10 +2,8 @@ using AutoFixture;
 using CautionaryAlertsListener.Infrastructure;
 using Hackney.Shared.CautionaryAlerts.Factories;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
-using Hackney.Shared.Tenure.Boundary.Response;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
 {

--- a/CautionaryAlertsListener.Tests/E2ETests/Fixtures/TenureApiFixture.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Fixtures/TenureApiFixture.cs
@@ -93,7 +93,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
         }
         public TenureInformation GivenTheTenureExists(Guid id, Guid? personId)
         {
-            var cautionaryFixture = CreateCautionaryAlertFixture.GenerateValidCreateCautionaryAlertFixture(_defaultString, _fixture);
+            var cautionaryFixture = CreateCautionaryAlertFixture.GenerateValidCreateCautionaryAlertFixture(_defaultString, _fixture, personId);
             var tenureAsset = new TenuredAsset()
             {
                 PropertyReference = cautionaryFixture.AssetDetails.PropertyReference,

--- a/CautionaryAlertsListener.Tests/E2ETests/Steps/PersonRemovedFromTenureUseCaseSteps.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Steps/PersonRemovedFromTenureUseCaseSteps.cs
@@ -12,7 +12,6 @@ using Xunit;
 using CautionaryAlertsListener.Infrastructure;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
 using FluentAssertions;
-using Hackney.Shared.Tenure.Boundary.Response;
 using Hackney.Shared.Tenure.Domain;
 using System.Linq;
 using CautionaryAlertsListener.Infrastructure.Exceptions;

--- a/CautionaryAlertsListener.Tests/E2ETests/Steps/PersonUpdatedUseCaseSteps.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Steps/PersonUpdatedUseCaseSteps.cs
@@ -7,7 +7,6 @@ using Hackney.Core.Sns;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using System;
-using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
@@ -47,6 +47,41 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
         }
 
         [Fact]
+        public void PropertyAlertForNoPersonAddedShouldThrow()
+        {
+            this.Given(g => _steps.GivenAMessageWithNoPersonAdded(_tenureApiFixture.ResponseObject))
+                .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
+                .Then(t => _steps.ThenAHouseholdMembersNotChangedExceptionIsThrown(_tenureApiFixture.ResponseObject.Id))
+                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
+            .BDDfy();
+        }
+
+        [Fact]
+        public void PropertyAlertForPersonNotFound()
+        {
+            var tenureId = Guid.NewGuid();
+            this.Given(g => _tenureApiFixture.GivenTheTenureExists(tenureId))
+                .And(g => _steps.GivenAMessageWithPersonAdded(_tenureApiFixture.ResponseObject))
+                .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
+                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
+                .Then(t => _steps.ThenNoExceptionIsThrown())
+                .Then(t => _steps.ThenNothingShouldBeDone())
+            .BDDfy();
+        }
+
+        [Fact]
+        public void TenureNotFoundShouldThrow()
+        {
+            var tenureId = Guid.NewGuid();
+            this.Given(g => _tenureApiFixture.GivenTheTenureDoesNotExist(tenureId))
+                .And(g => _steps.GivenAMessageWithPersonAdded(_tenureApiFixture.ResponseObject))
+                .When(w => _steps.WhenTheFunctionIsTriggered(tenureId))
+                .Then(t => _steps.ThenATenureNotFoundExceptionIsThrown(tenureId))
+                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
+                .BDDfy();
+        }
+
+        [Fact]
         public void ListenerUpdatesTheCautionaryAlert()
         {
             var tenureId = Guid.NewGuid();
@@ -58,46 +93,6 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
                 .Then(t => _steps.ThenTheAlertIsUpdated(_cautionaryAlertFixture.DbEntity, _tenureApiFixture.ResponseObject,
                                                          _dbFixture))
                 .BDDfy();
-        }
-
-        [Fact]
-        public void TenureNotFound()
-        {
-            var tenureId = Guid.NewGuid();
-            this.Given(g => _tenureApiFixture.GivenTheTenureDoesNotExist(tenureId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(tenureId))
-                .Then(t => _steps.ThenATenureNotFoundExceptionIsThrown(tenureId))
-                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void PropertyAlertForPersonNotFound()
-        {
-            var mmhId = Guid.NewGuid();
-            var tenureId = Guid.NewGuid();
-            this.Given(g => _cautionaryAlertFixture.GivenACautionaryAlertDoesNotExistForPerson(mmhId))
-                .And(g => _tenureApiFixture.GivenTheTenureExists(tenureId))
-                .And(g => _steps.GivenAMessageWithPersonAdded(_tenureApiFixture.ResponseObject))
-                .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
-                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
-                .Then(t => _steps.ThenNoExceptionIsThrown())
-                .Then(t => _steps.ThenNothingShouldBeDone())
-            .BDDfy();
-        }
-
-        [Fact]
-        public void PropertyAlertForNoPersonAddedShouldThrow()
-        {
-            var mmhId = Guid.NewGuid();
-            var tenureId = Guid.NewGuid();
-            this.Given(g => _cautionaryAlertFixture.GivenACautionaryAlertDoesNotExistForPerson(mmhId))
-                .And(g => _tenureApiFixture.GivenTheTenureExists(tenureId))
-                .And(g => _steps.GivenAMessageWithNoPersonAdded(_tenureApiFixture.ResponseObject))
-                .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
-                .Then(t => _steps.ThenAHouseholdMembersNotChangedExceptionIsThrown(tenureId))
-                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
-            .BDDfy();
         }
     }
 }

--- a/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
@@ -49,21 +49,18 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
         [Fact]
         public void PropertyAlertForNoPersonAddedShouldThrow()
         {
-            this.Given(g => _steps.GivenAMessageWithNoPersonAdded(_tenureApiFixture.ResponseObject))
+            this.Given(g => _steps.GivenAMessageWithNoPersonAdded())
                 .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
-                .Then(t => _steps.ThenAHouseholdMembersNotChangedExceptionIsThrown(_tenureApiFixture.ResponseObject.Id))
-                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
+                .Then(t => _steps.ThenAHouseholdMembersNotChangedExceptionIsThrown(_steps.TenureId))
             .BDDfy();
         }
 
         [Fact]
         public void PropertyAlertForPersonNotFound()
         {
-            var tenureId = Guid.NewGuid();
-            this.Given(g => _tenureApiFixture.GivenTheTenureExists(tenureId))
-                .And(g => _steps.GivenAMessageWithPersonAdded(_tenureApiFixture.ResponseObject))
+            this.Given(g => _steps.GivenAMessageWithPersonAdded())
+                .And(g => _cautionaryAlertFixture.GivenACautionaryAlertDoesNotExistForPerson(_steps.NewPersonId))
                 .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
-                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
                 .Then(t => _steps.ThenNoExceptionIsThrown())
                 .Then(t => _steps.ThenNothingShouldBeDone())
             .BDDfy();
@@ -72,11 +69,11 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
         [Fact]
         public void TenureNotFoundShouldThrow()
         {
-            var tenureId = Guid.NewGuid();
-            this.Given(g => _tenureApiFixture.GivenTheTenureDoesNotExist(tenureId))
-                .And(g => _steps.GivenAMessageWithPersonAdded(_tenureApiFixture.ResponseObject))
-                .When(w => _steps.WhenTheFunctionIsTriggered(tenureId))
-                .Then(t => _steps.ThenATenureNotFoundExceptionIsThrown(tenureId))
+            this.Given(g => _steps.GivenAMessageWithPersonAdded())
+                .And(h => _cautionaryAlertFixture.GivenTheCautionaryAlertAlreadyExist(_steps.NewPersonId, null))
+                .And(g => _tenureApiFixture.GivenTheTenureDoesNotExist(_steps.TenureId))
+                .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
+                .Then(t => _steps.ThenATenureNotFoundExceptionIsThrown(_steps.TenureId))
                 .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
                 .BDDfy();
         }
@@ -90,8 +87,8 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
                 .And(h => _cautionaryAlertFixture.GivenTheCautionaryAlertAlreadyExist(_steps.NewPersonId, null))
                 .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
                 .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
-                .Then(t => _steps.ThenTheAlertIsUpdated(_cautionaryAlertFixture.DbEntity, _tenureApiFixture.ResponseObject,
-                                                         _dbFixture))
+                .Then(t => _steps.ThenANewAlertIsAdded(_cautionaryAlertFixture.DbEntity, _tenureApiFixture.ResponseObject,
+                                                       _dbFixture))
                 .BDDfy();
         }
     }

--- a/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
@@ -87,7 +87,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
             var tenureId = Guid.NewGuid();
             this.Given(g => _tenureApiFixture.GivenTheTenureExists(tenureId))
                 .And(h => _steps.GivenAMessageWithPersonAdded(_tenureApiFixture.ResponseObject))
-                .And(h => _cautionaryAlertFixture.GivenTheCautionaryAlertAlreadyExist(_steps.NewPersonId, _tenureApiFixture.ResponseObject.TenuredAsset.PropertyReference))
+                .And(h => _cautionaryAlertFixture.GivenTheCautionaryAlertAlreadyExist(_steps.NewPersonId, null))
                 .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
                 .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
                 .Then(t => _steps.ThenTheAlertIsUpdated(_cautionaryAlertFixture.DbEntity, _tenureApiFixture.ResponseObject,

--- a/CautionaryAlertsListener.Tests/E2ETests/Stories/RemovePersonFromTenureTests.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Stories/RemovePersonFromTenureTests.cs
@@ -53,7 +53,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
             var mmhId = Guid.NewGuid();
             var tenureId = Guid.NewGuid();
             this.Given(g => _cautionaryAlertFixture.GivenACautionaryAlertDoesNotExistForPerson(mmhId))
-                .And(g => _tenureApiFixture.GivenTheTenureExists(tenureId))
+                .And(g => _tenureApiFixture.GivenTheTenureExists(tenureId, mmhId))
                 .And(g => _steps.GivenAMessageWithPersonRemoved(_tenureApiFixture.ResponseObject))
                 .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
                 .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))

--- a/CautionaryAlertsListener.Tests/Gateway/CautionaryAlertGatewayTests.cs
+++ b/CautionaryAlertsListener.Tests/Gateway/CautionaryAlertGatewayTests.cs
@@ -2,7 +2,6 @@ using AutoFixture;
 using Bogus;
 using CautionaryAlertsListener.Gateway;
 using FluentAssertions;
-using FluentValidation;
 using Hackney.Core.Testing.Shared;
 using Hackney.Shared.CautionaryAlerts.Factories;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
@@ -11,7 +10,6 @@ using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace CautionaryAlertsListener.Tests.Gateway
@@ -38,35 +36,35 @@ namespace CautionaryAlertsListener.Tests.Gateway
         }
 
         [Test]
-        public async Task GetEntitiesByMMHAndPropertyReferenceAsyncReturnsNullIfNoneFound()
+        public async Task GetEntitiesByMMHIdAndPropertyReferenceAsyncReturnsNullIfNoneFound()
         {
-            var response = await _classUnderTest.GetEntitiesByMMHAndPropertyReferenceAsync(_fixture.Create<Guid>().ToString());
+            var response = await _classUnderTest.GetEntitiesByMMHIdAndPropertyReferenceAsync(_fixture.Create<Guid>().ToString());
             response.Should().BeEmpty();
         }
 
         [Test]
-        public async Task GetEntitiesByMMHAndPropertyReferenceAsyncReturnsCollectionIfFoundOnMMHID()
+        public async Task GetEntitiesByMMHIdAndPropertyReferenceAsyncReturnsCollectionIfFoundOnMMHID()
         {
             var dbEntity = await AddAlertToDb();
-            var response = await _classUnderTest.GetEntitiesByMMHAndPropertyReferenceAsync(dbEntity.MMHID);
+            var response = await _classUnderTest.GetEntitiesByMMHIdAndPropertyReferenceAsync(dbEntity.MMHID);
             response.Should().NotBeNull();
             response.Should().NotBeEmpty();
             response.Should().BeEquivalentTo(new List<PropertyAlertNew> { dbEntity });
         }
 
         [Test]
-        public async Task GetEntitiesByMMHAndPropertyReferenceAsyncReturnsCollectionIfFoundOnMMHIDAndPropertyReference()
+        public async Task GetEntitiesByMMHIdAndPropertyReferenceAsyncReturnsCollectionIfFoundOnMMHIDAndPropertyReference()
         {
             var dbEntity = await AddAlertToDb();
-            var response = await _classUnderTest.GetEntitiesByMMHAndPropertyReferenceAsync(dbEntity.MMHID, dbEntity.PropertyReference);
+            var response = await _classUnderTest.GetEntitiesByMMHIdAndPropertyReferenceAsync(dbEntity.MMHID, dbEntity.PropertyReference);
             response.Should().NotBeEmpty();
             response.Should().BeEquivalentTo(new List<PropertyAlertNew> { dbEntity });
         }
 
         [Test]
-        public async Task GetEntitiesByMMHAndPropertyReferenceAsyncThrowsOnMissingMMHID()
+        public async Task GetEntitiesByMMHIdAndPropertyReferenceAsyncThrowsOnMissingMMHID()
         {
-            Func<Task> func = async () => await _classUnderTest.GetEntitiesByMMHAndPropertyReferenceAsync(null).ConfigureAwait(false);
+            Func<Task> func = async () => await _classUnderTest.GetEntitiesByMMHIdAndPropertyReferenceAsync(null).ConfigureAwait(false);
             await func.Should().ThrowAsync<ArgumentNullException>();
         }
 
@@ -78,7 +76,7 @@ namespace CautionaryAlertsListener.Tests.Gateway
             dbEntity.PersonName = updatedPersonName;
             await CautionaryAlertContext.SaveChangesAsync();
 
-            var responseCollection = await _classUnderTest.GetEntitiesByMMHAndPropertyReferenceAsync(dbEntity.MMHID);
+            var responseCollection = await _classUnderTest.GetEntitiesByMMHIdAndPropertyReferenceAsync(dbEntity.MMHID);
             responseCollection.Should().NotBeEmpty();
             foreach (var item in responseCollection)
             {

--- a/CautionaryAlertsListener.Tests/Gateway/TenureApiGatewayTests.cs
+++ b/CautionaryAlertsListener.Tests/Gateway/TenureApiGatewayTests.cs
@@ -1,6 +1,5 @@
 using AutoFixture;
 using Hackney.Core.Http;
-using Hackney.Shared.Tenure.Boundary.Response;
 using Moq;
 using System.Threading.Tasks;
 using System;

--- a/CautionaryAlertsListener.Tests/MockApplicationFactory.cs
+++ b/CautionaryAlertsListener.Tests/MockApplicationFactory.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System;
 
 namespace CautionaryAlertsListener.Tests
 {

--- a/CautionaryAlertsListener.Tests/UseCase/AddPersonToTenureUseCaseTests.cs
+++ b/CautionaryAlertsListener.Tests/UseCase/AddPersonToTenureUseCaseTests.cs
@@ -109,7 +109,19 @@ namespace CautionaryAlertsListener.Tests.UseCase
             func.Should().ThrowAsync<HouseholdMembersNotChangedException>();
         }
 
+        [Fact]
+        public async Task ProcessMessageAsyncTestPersonIdNotFoundDoesNotCallSaveEntitiesAsync()
+        {
+            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<Guid>().ToString(), null))
+                .ReturnsAsync(new List<PropertyAlertNew>());
 
+            _mockTenureApi.Setup(x => x.GetTenureByIdAsync(_message.EntityId, _message.CorrelationId))
+                                       .ReturnsAsync(_tenure);
+            Func<Task> func = async () => await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
+            await func.Should().NotThrowAsync();
+            _mockGateway.Verify(x => x.SaveEntitiesAsync(It.IsAny<IEnumerable<PropertyAlertNew>>()), Times.Never);
+        }
+        
         [Fact]
         public async Task ProcessMessageAsyncTestGetTenureExceptionThrown()
         {
@@ -134,19 +146,6 @@ namespace CautionaryAlertsListener.Tests.UseCase
 
             Func<Task> func = async () => await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
             await func.Should().ThrowAsync<EntityNotFoundException<TenureInformation>>();
-        }
-
-        [Fact]
-        public async Task ProcessMessageAsyncTestPersonIdNotFoundDoesNotCallSaveEntitiesAsync()
-        {
-            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<Guid>().ToString(), null))
-                .ReturnsAsync(new List<PropertyAlertNew>());
-
-            _mockTenureApi.Setup(x => x.GetTenureByIdAsync(_message.EntityId, _message.CorrelationId))
-                                       .ReturnsAsync(_tenure);
-            Func<Task> func = async () => await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
-            await func.Should().NotThrowAsync();
-            _mockGateway.Verify(x => x.SaveEntitiesAsync(It.IsAny<IEnumerable<PropertyAlertNew>>()), Times.Never);
         }
 
         [Fact]

--- a/CautionaryAlertsListener.Tests/UseCase/AddPersonToTenureUseCaseTests.cs
+++ b/CautionaryAlertsListener.Tests/UseCase/AddPersonToTenureUseCaseTests.cs
@@ -121,7 +121,7 @@ namespace CautionaryAlertsListener.Tests.UseCase
             await func.Should().NotThrowAsync();
             _mockGateway.Verify(x => x.SaveEntitiesAsync(It.IsAny<IEnumerable<PropertyAlertNew>>()), Times.Never);
         }
-        
+
         [Fact]
         public async Task ProcessMessageAsyncTestGetTenureExceptionThrown()
         {

--- a/CautionaryAlertsListener.Tests/UseCase/PersonUpdatedUseCaseTests.cs
+++ b/CautionaryAlertsListener.Tests/UseCase/PersonUpdatedUseCaseTests.cs
@@ -74,7 +74,7 @@ namespace CautionaryAlertsListener.Tests.UseCase
         {
             _message = SetMessageEventData(_message);
             var mmhId = _message.Id;
-            _mockGateway.Setup(x => x.GetEntitiesByMMHAndPropertyReferenceAsync(It.IsAny<Guid>().ToString(), null))
+            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<Guid>().ToString(), null))
                 .ReturnsAsync(new List<PropertyAlertNew>());
 
             Func<Task> func = async () => await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
@@ -92,7 +92,7 @@ namespace CautionaryAlertsListener.Tests.UseCase
                         .Create()
                 };
             _message = SetMessageEventData(_message);
-            _mockGateway.Setup(x => x.GetEntitiesByMMHAndPropertyReferenceAsync(It.IsAny<string>(), It.IsAny<string>()))
+            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(response);
 
             var verifyList = new List<PropertyAlertNew>() { It.IsAny<PropertyAlertNew>() };

--- a/CautionaryAlertsListener.Tests/UseCase/RemovePersonFromTenureUseCaseTests.cs
+++ b/CautionaryAlertsListener.Tests/UseCase/RemovePersonFromTenureUseCaseTests.cs
@@ -11,7 +11,6 @@ using CautionaryAlertsListener.UseCase;
 using System.Linq;
 using Force.DeepCloner;
 using FluentAssertions;
-using CautionaryAlertsListener.Infrastructure;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
 using Hackney.Shared.Tenure.Domain;
 
@@ -117,11 +116,11 @@ namespace CautionaryAlertsListener.Tests.UseCase
         }
 
         [Fact]
-        public async Task ProcessMessageAsyncTestPersonIdNotFoundDoesNoting()
+        public async Task ProcessMessageAsyncTestPersonIdNotFoundDoesNothing()
         {
             SetMessageEventData(_tenure, _message);
 
-            _mockGateway.Setup(x => x.GetEntitiesByMMHAndPropertyReferenceAsync(It.IsAny<Guid>().ToString(), null))
+            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<Guid>().ToString(), null))
                 .ReturnsAsync((List<PropertyAlertNew>) null);
             _mockTenureApi.Setup(x => x.GetTenureByIdAsync(_message.EntityId, _message.CorrelationId))
                                        .ReturnsAsync(_tenure);
@@ -137,17 +136,17 @@ namespace CautionaryAlertsListener.Tests.UseCase
             SetMessageEventData(_tenure, _message);
 
             _mockTenureApi.Setup(x => x.GetTenureByIdAsync(It.IsAny<Guid>(), _correlationId)).ReturnsAsync(_tenure);
-            _mockGateway.Setup(x => x.GetEntitiesByMMHAndPropertyReferenceAsync(It.IsAny<string>(), It.IsAny<string>()))
+            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<PropertyAlertNew>() { _fixture.Create<PropertyAlertNew>() });
 
             var exMsg = "This is the last error";
-            _mockGateway.Setup(x => x.UpdateEntityAsync(It.IsAny<PropertyAlertNew>()))
+            _mockGateway.Setup(x => x.UpdateEntitiesAsync(It.IsAny<IEnumerable<PropertyAlertNew>>()))
                         .ThrowsAsync(new Exception(exMsg));
 
             Func<Task> func = async () => await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
             func.Should().ThrowAsync<Exception>().WithMessage(exMsg);
 
-            _mockGateway.Verify(x => x.UpdateEntityAsync(It.IsAny<PropertyAlertNew>()), Times.Once);
+            _mockGateway.Verify(x => x.UpdateEntitiesAsync(It.IsAny<IEnumerable<PropertyAlertNew>>()), Times.Once);
         }
 
         [Fact]
@@ -156,11 +155,11 @@ namespace CautionaryAlertsListener.Tests.UseCase
             SetMessageEventData(_tenure, _message);
 
             _mockTenureApi.Setup(x => x.GetTenureByIdAsync(It.IsAny<Guid>(), _correlationId)).ReturnsAsync(_tenure);
-            _mockGateway.Setup(x => x.GetEntitiesByMMHAndPropertyReferenceAsync(It.IsAny<string>(), It.IsAny<string>()))
+            _mockGateway.Setup(x => x.GetEntitiesByMMHIdAndPropertyReferenceAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(new List<PropertyAlertNew>() { _fixture.Create<PropertyAlertNew>() });
 
             await _sut.ProcessMessageAsync(_message).ConfigureAwait(false);
-            _mockGateway.Verify(x => x.UpdateEntityAsync(It.IsAny<PropertyAlertNew>()), Times.Once);
+            _mockGateway.Verify(x => x.UpdateEntitiesAsync(It.IsAny<IEnumerable<PropertyAlertNew>>()), Times.Once);
         }
     }
 }

--- a/CautionaryAlertsListener/BaseFunction.cs
+++ b/CautionaryAlertsListener/BaseFunction.cs
@@ -1,5 +1,3 @@
-using Amazon.XRay.Recorder.Core;
-using Amazon.XRay.Recorder.Core.Strategies;
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using CautionaryAlertsListener.Infrastructure;
 using Hackney.Core.Logging;

--- a/CautionaryAlertsListener/CautionaryAlertsListener.cs
+++ b/CautionaryAlertsListener/CautionaryAlertsListener.cs
@@ -1,13 +1,11 @@
 using Amazon.Lambda.Core;
 using Amazon.Lambda.SQSEvents;
-using CautionaryAlertsListener.Boundary;
 using CautionaryAlertsListener.Factories;
 using CautionaryAlertsListener.Gateway;
 using CautionaryAlertsListener.Gateway.Interfaces;
 using CautionaryAlertsListener.Infrastructure;
 using CautionaryAlertsListener.UseCase;
 using CautionaryAlertsListener.UseCase.Interfaces;
-using Hackney.Core.DynamoDb;
 using Hackney.Core.Http;
 using Hackney.Core.Logging;
 using Hackney.Core.Sns;

--- a/CautionaryAlertsListener/Gateway/CautionaryAlertGateway.cs
+++ b/CautionaryAlertsListener/Gateway/CautionaryAlertGateway.cs
@@ -1,4 +1,3 @@
-using Amazon.XRay.Recorder.Core.Internal.Entities;
 using CautionaryAlertsListener.Gateway.Interfaces;
 using CautionaryAlertsListener.Infrastructure;
 using Hackney.Core.Logging;
@@ -24,7 +23,7 @@ namespace CautionaryAlertsListener.Gateway
         }
 
         [LogCall]
-        public async Task<ICollection<PropertyAlertNew>> GetEntitiesByMMHAndPropertyReferenceAsync(string mmhId, string propertyReference = null)
+        public async Task<ICollection<PropertyAlertNew>> GetEntitiesByMMHIdAndPropertyReferenceAsync(string mmhId, string propertyReference = null)
         {
             if (string.IsNullOrEmpty(mmhId))
             {
@@ -71,6 +70,15 @@ namespace CautionaryAlertsListener.Gateway
             foreach (var propertyAlert in propertyAlerts)
                 _cautionaryAlertDbContext.PropertyAlerts.Update(propertyAlert);
 
+            await _cautionaryAlertDbContext.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        [LogCall]
+        public async Task SaveEntitiesAsync(IEnumerable<PropertyAlertNew> entities)
+        {
+            _logger.LogDebug($"Calling Postgress.SaveAsync");
+
+            _cautionaryAlertDbContext.PropertyAlerts.AddRange(entities);
             await _cautionaryAlertDbContext.SaveChangesAsync().ConfigureAwait(false);
         }
     }

--- a/CautionaryAlertsListener/Gateway/Interfaces/ICautionaryAlertGateway.cs
+++ b/CautionaryAlertsListener/Gateway/Interfaces/ICautionaryAlertGateway.cs
@@ -6,7 +6,8 @@ namespace CautionaryAlertsListener.Gateway.Interfaces
 {
     public interface ICautionaryAlertGateway
     {
-        Task<ICollection<PropertyAlertNew>> GetEntitiesByMMHAndPropertyReferenceAsync(string mmhId, string tenureId = null);
+        Task<ICollection<PropertyAlertNew>> GetEntitiesByMMHIdAndPropertyReferenceAsync(string mmhId, string propertyReference = null);
+        Task SaveEntitiesAsync(IEnumerable<PropertyAlertNew> entities);
         Task UpdateEntityAsync(PropertyAlertNew entity);
         Task UpdateEntitiesAsync(IEnumerable<PropertyAlertNew> propertyAlerts);
     }

--- a/CautionaryAlertsListener/Infrastructure/Exceptions/HouseholdMembersNotChangedException.cs
+++ b/CautionaryAlertsListener/Infrastructure/Exceptions/HouseholdMembersNotChangedException.cs
@@ -14,5 +14,9 @@ namespace CautionaryAlertsListener.Infrastructure.Exceptions
             TenureId = tenureId;
             CorrelationId = correlationId;
         }
+
+        public HouseholdMembersNotChangedException() : base("There are no new or changed household member records on the tenure.")
+        {
+        }
     }
 }

--- a/CautionaryAlertsListener/Infrastructure/Helpers.cs
+++ b/CautionaryAlertsListener/Infrastructure/Helpers.cs
@@ -1,4 +1,5 @@
 using CautionaryAlertsListener.Factories;
+using CautionaryAlertsListener.Infrastructure.Exceptions;
 using Hackney.Shared.Tenure.Domain;
 using System.Collections.Generic;
 
@@ -9,8 +10,9 @@ namespace CautionaryAlertsListener.Infrastructure
         public static List<HouseholdMembers> GetHouseholdMembersFromEventData(object data)
         {
             var dataDic = (data is Dictionary<string, object>) ? data as Dictionary<string, object> : ObjectFactory.ConvertFromObject<Dictionary<string, object>>(data);
-            var hmsObj = dataDic["householdMembers"];
-            return (hmsObj is List<HouseholdMembers>) ? hmsObj as List<HouseholdMembers> : ObjectFactory.ConvertFromObject<List<HouseholdMembers>>(hmsObj);
+            if (dataDic.TryGetValue("householdMembers", out var hmsObj))
+                return (hmsObj is List<HouseholdMembers>) ? hmsObj as List<HouseholdMembers> : ObjectFactory.ConvertFromObject<List<HouseholdMembers>>(hmsObj);
+            throw new HouseholdMembersNotChangedException();
         }
     }
 }

--- a/CautionaryAlertsListener/UseCase/Interfaces/IMessageProcessing.cs
+++ b/CautionaryAlertsListener/UseCase/Interfaces/IMessageProcessing.cs
@@ -1,4 +1,3 @@
-using CautionaryAlertsListener.Boundary;
 using Hackney.Core.Sns;
 using System.Threading.Tasks;
 

--- a/CautionaryAlertsListener/UseCase/PersonUpdatedUseCase.cs
+++ b/CautionaryAlertsListener/UseCase/PersonUpdatedUseCase.cs
@@ -1,16 +1,12 @@
 using CautionaryAlertsListener.Gateway.Interfaces;
-using CautionaryAlertsListener.Infrastructure.Exceptions;
 using CautionaryAlertsListener.UseCase.Interfaces;
 using Hackney.Core.Logging;
 using System.Threading.Tasks;
 using System;
-using CautionaryAlertsListener.Infrastructure;
 using System.Collections.Generic;
 using Hackney.Core.Sns;
-using Microsoft.EntityFrameworkCore.Internal;
 using System.Linq;
 using Hackney.Shared.CautionaryAlerts.Infrastructure;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace CautionaryAlertsListener.UseCase
@@ -29,15 +25,15 @@ namespace CautionaryAlertsListener.UseCase
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
 
-            var entityCollection = await _gateway.GetEntitiesByMMHAndPropertyReferenceAsync(message.EntityId.ToString()).ConfigureAwait(false);
-            if (entityCollection is null || !entityCollection.Any()) return;
+            var cautionaryAlerts = await _gateway.GetEntitiesByMMHIdAndPropertyReferenceAsync(message.EntityId.ToString()).ConfigureAwait(false);
+            if (cautionaryAlerts is null || !cautionaryAlerts.Any()) return;
 
             var deserializedNewData = JObject.Parse(message.EventData.NewData.ToString());
             var deresializedOldData = JObject.Parse(message.EventData.OldData.ToString());
             var propCollection = deserializedNewData.Properties().ToList();
 
             var collectionToUpdate = new List<PropertyAlertNew>();
-            foreach (var entity in entityCollection)
+            foreach (var entity in cautionaryAlerts)
             {
                 foreach (var property in propCollection)
                 {

--- a/CautionaryAlertsListener/UseCase/RemovePersonFromTenureUseCase.cs
+++ b/CautionaryAlertsListener/UseCase/RemovePersonFromTenureUseCase.cs
@@ -34,7 +34,7 @@ namespace CautionaryAlertsListener.UseCase
             if (householdMember is null) throw new HouseholdMembersNotChangedException(message.EntityId, message.CorrelationId);
 
             var alerts = await _gateway.GetEntitiesByMMHIdAndPropertyReferenceAsync(householdMember.Id.ToString(), tenure.TenuredAsset.PropertyReference);
-            if (alerts is null) return;
+            if (alerts is null || !alerts.Any()) return;
 
             foreach (var item in alerts)
             {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -623,7 +623,7 @@ create table dbo."CCAddress"(
 );
 
 
-create table dbo."PropertyAlertNew"(
+CREATE TABLE dbo."PropertyAlertNew"(
 	"id" SERIAL PRIMARY KEY NOT NULL,
 	"door_number" varchar(10),
 	"address" varchar(50),


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve?*

The logic to update cautionary alerts based on changes to a person's tenure(s) is flawed. This means that when a person is added to or removed from a tenancy, the relevant property is not updated correctly.

### *What changes have we introduced?*
- When a person is added to a tenure, a new record is added with their alert against the new property.
- When a person is removed from a tenure, *all* alerts against that property will be made null.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test the complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
