### PR TITLE
AddPersonToTenure updates existing alert

### DIFF
--- a/CautionaryAlertsListener.Tests/CreateCautionaryAlertsFixture.cs
+++ b/CautionaryAlertsListener.Tests/CreateCautionaryAlertsFixture.cs
@@ -16,14 +16,14 @@ namespace CautionaryAlertsListener.Tests
             public static CreateCautionaryAlert GenerateValidCreateCautionaryAlertFixture(string defaultString, Fixture fixture, string addressString, Guid? mmhId = null, string propertyReference = null)
             {
                 var alert = fixture.Build<Alert>()
-                    .With(x => x.Code, defaultString[..CreateCautionaryAlertConstants.ALERTCODELENGTH])
-                    .With(x => x.Description, defaultString[..CreateCautionaryAlertConstants.ALERTDESCRIPTION])
+                    .With(x => x.Code, defaultString[..CautionaryAlertConstants.ALERTCODELENGTH])
+                    .With(x => x.Description, defaultString[..CautionaryAlertConstants.ALERTDESCRIPTION])
                     .Create();
 
                 var assetDetails = fixture.Build<AssetDetails>()
-                    .With(x => x.FullAddress, addressString[..CreateCautionaryAlertConstants.FULLADDRESSLENGTH])
-                    .With(x => x.UPRN, defaultString[..CreateCautionaryAlertConstants.UPRNLENGTH])
-                    .With(x => x.PropertyReference, propertyReference ?? defaultString[..CreateCautionaryAlertConstants.PROPERTYREFERENCELENGTH])
+                    .With(x => x.FullAddress, addressString[..CautionaryAlertConstants.FULLADDRESSLENGTH])
+                    .With(x => x.UPRN, defaultString[..CautionaryAlertConstants.UPRNLENGTH])
+                    .With(x => x.PropertyReference, propertyReference ?? defaultString[..CautionaryAlertConstants.PROPERTYREFERENCELENGTH])
                     .Create();
 
                 var personDetails = fixture.Build<PersonDetails>()
@@ -35,9 +35,9 @@ namespace CautionaryAlertsListener.Tests
                     .With(x => x.Alert, alert)
                     .With(x => x.PersonDetails, personDetails)
                     .With(x => x.AssetDetails, assetDetails)
-                    .With(x => x.IncidentDescription, defaultString[..CreateCautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH])
+                    .With(x => x.IncidentDescription, defaultString[..CautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH])
                     .With(x => x.IncidentDate, fixture.Create<DateTime>().AddDays(-1))
-                    .With(x => x.AssureReference, defaultString[..CreateCautionaryAlertConstants.ASSUREREFERENCELENGTH])
+                    .With(x => x.AssureReference, defaultString[..CautionaryAlertConstants.ASSUREREFERENCELENGTH])
                     .Create();
 
                 return cautionaryAlert;

--- a/CautionaryAlertsListener.Tests/E2ETests/Fixtures/CautionaryAlertFixture.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Fixtures/CautionaryAlertFixture.cs
@@ -23,7 +23,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
         public CautionaryAlertFixture(CautionaryAlertContext dbContext)
         {
             _dbContext = dbContext;
-            _defaultString = string.Join("", _fixture.CreateMany<char>(CreateCautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH));
+            _defaultString = string.Join("", _fixture.CreateMany<char>(CautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH));
         }
 
         public void Dispose()
@@ -45,9 +45,9 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
 
         private PropertyAlertNew ConstructAndSaveCautionaryAlertMMHIDOptionalPropertyReference(Guid mmhId, string propertyReference = null)
         {
-            var addressString = string.Join("", _fixture.CreateMany<char>(CreateCautionaryAlertConstants.FULLADDRESSLENGTH));
+            var addressString = string.Join("", _fixture.CreateMany<char>(CautionaryAlertConstants.FULLADDRESSLENGTH));
             var cautionaryAlert = CreateCautionaryAlertFixture.GenerateValidCreateCautionaryAlertFixture(_defaultString, _fixture, addressString, mmhId, propertyReference);
-            var dbEntity = cautionaryAlert.ToDatabase();
+            var dbEntity = cautionaryAlert.ToDatabase(isActive: true, Guid.NewGuid().ToString());
             _dbContext.PropertyAlerts.Add(dbEntity);
             _dbContext.SaveChanges();
             return dbEntity;

--- a/CautionaryAlertsListener.Tests/E2ETests/Fixtures/TenureApiFixture.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Fixtures/TenureApiFixture.cs
@@ -26,7 +26,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
         {
             Environment.SetEnvironmentVariable("TenureApiUrl", FixtureConstants.TenureApiRoute);
             Environment.SetEnvironmentVariable("TenureApiToken", FixtureConstants.TenureApiToken);
-            _defaultString = string.Join("", _fixture.CreateMany<char>(CreateCautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH));
+            _defaultString = string.Join("", _fixture.CreateMany<char>(CautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH));
         }
 
         protected override void Dispose(bool disposing)
@@ -95,7 +95,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Fixtures
         }
         public TenureInformation GivenTheTenureExists(Guid id, Guid? personId)
         {
-            var addressString = string.Join("", _fixture.CreateMany<char>(CreateCautionaryAlertConstants.FULLADDRESSLENGTH));
+            var addressString = string.Join("", _fixture.CreateMany<char>(CautionaryAlertConstants.FULLADDRESSLENGTH));
             var cautionaryFixture = CreateCautionaryAlertFixture.GenerateValidCreateCautionaryAlertFixture(_defaultString, _fixture, addressString, personId);
             var tenureAsset = new TenuredAsset()
             {

--- a/CautionaryAlertsListener.Tests/E2ETests/Steps/PersonAddedToTenureUseCaseSteps.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Steps/PersonAddedToTenureUseCaseSteps.cs
@@ -94,22 +94,21 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Steps
             (_lastException as HouseholdMembersNotChangedException).TenureId.Should().Be(tenureId);
         }
 
-        public async Task ThenANewAlertIsAdded(PropertyAlertNew oldAlert, TenureInformation tenure, CautionaryAlertContext dbContext)
+        public async Task ThenAlertIsUpdated(PropertyAlertNew alert, TenureInformation tenure, CautionaryAlertContext dbContext)
         {
-            var newAlert = await dbContext.PropertyAlerts.AsNoTracking()
-                                                         .Where(x => x.MMHID == oldAlert.MMHID && x.Id != oldAlert.Id)
+            var updatedAlert = await dbContext.PropertyAlerts.AsNoTracking()
+                                                         .Where(x => x.MMHID == alert.MMHID && x.Id == alert.Id)
                                                          .FirstAsync();
 
-            newAlert.Should().NotBeNull();
-            newAlert.Should().BeEquivalentTo(oldAlert,
-                config => config.Excluding(x => x.Id)
-                                .Excluding(x => x.PropertyReference)
+            updatedAlert.Should().NotBeNull();
+            updatedAlert.Should().BeEquivalentTo(alert,
+                config => config.Excluding(x => x.PropertyReference)
                                 .Excluding(x => x.Address)
                                 .Excluding(x => x.UPRN));
 
-            newAlert.PropertyReference.Should().Be(tenure.TenuredAsset.PropertyReference);
-            newAlert.Address.Should().Be(tenure.TenuredAsset.FullAddress);
-            newAlert.UPRN.Should().Be(tenure.TenuredAsset.Uprn);
+            updatedAlert.PropertyReference.Should().Be(tenure.TenuredAsset.PropertyReference);
+            updatedAlert.Address.Should().Be(tenure.TenuredAsset.FullAddress);
+            updatedAlert.UPRN.Should().Be(tenure.TenuredAsset.Uprn);
         }
 
         private SQSEvent.SQSMessage CreateMessage(Guid personId, EventData eventData, string eventType = EventTypes.PersonRemovedFromTenureEvent)

--- a/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
+++ b/CautionaryAlertsListener.Tests/E2ETests/Stories/PersonAddedToTenureTests.cs
@@ -87,7 +87,7 @@ namespace CautionaryAlertsListener.Tests.E2ETests.Stories
                 .And(h => _cautionaryAlertFixture.GivenTheCautionaryAlertAlreadyExist(_steps.NewPersonId, null))
                 .When(w => _steps.WhenTheFunctionIsTriggered(_steps.TheMessage))
                 .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_tenureApiFixture.ReceivedCorrelationIds))
-                .Then(t => _steps.ThenANewAlertIsAdded(_cautionaryAlertFixture.DbEntity, _tenureApiFixture.ResponseObject,
+                .Then(t => _steps.ThenAlertIsUpdated(_cautionaryAlertFixture.DbEntity, _tenureApiFixture.ResponseObject,
                                                        _dbFixture))
                 .BDDfy();
         }

--- a/CautionaryAlertsListener.Tests/Gateway/CautionaryAlertGatewayTests.cs
+++ b/CautionaryAlertsListener.Tests/Gateway/CautionaryAlertGatewayTests.cs
@@ -33,7 +33,7 @@ namespace CautionaryAlertsListener.Tests.Gateway
             _mockedLogger = new Mock<ILogger<CautionaryAlertGateway>>();
             _classUnderTest = new CautionaryAlertGateway(CautionaryAlertContext, _mockedLogger.Object);
             _fixture = new Fixture();
-            _defaultString = string.Join("", _fixture.CreateMany<char>(CreateCautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH));
+            _defaultString = string.Join("", _fixture.CreateMany<char>(CautionaryAlertConstants.INCIDENTDESCRIPTIONLENGTH));
         }
 
         [Test]
@@ -87,9 +87,9 @@ namespace CautionaryAlertsListener.Tests.Gateway
 
         private async Task<PropertyAlertNew> AddAlertToDb()
         {
-            var addressString = string.Join("", _fixture.CreateMany<char>(CreateCautionaryAlertConstants.FULLADDRESSLENGTH));
+            var addressString = string.Join("", _fixture.CreateMany<char>(CautionaryAlertConstants.FULLADDRESSLENGTH));
             var alert = CreateCautionaryAlertFixture.GenerateValidCreateCautionaryAlertFixture(_defaultString, _fixture, addressString);
-            var dbEntity = alert.ToDatabase();
+            var dbEntity = alert.ToDatabase(isActive: true, Guid.NewGuid().ToString());
             CautionaryAlertContext.PropertyAlerts.Add(dbEntity);
             await CautionaryAlertContext.SaveChangesAsync();
             return dbEntity;

--- a/CautionaryAlertsListener/CautionaryAlertsListener.csproj
+++ b/CautionaryAlertsListener/CautionaryAlertsListener.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.9.0" />  
+    <PackageReference Include="Hackney.Shared.CautionaryAlerts" Version="0.19.0" />  
   </ItemGroup>
     
   <ItemGroup>

--- a/CautionaryAlertsListener/UseCase/AddPersonToTenureUseCase.cs
+++ b/CautionaryAlertsListener/UseCase/AddPersonToTenureUseCase.cs
@@ -39,25 +39,12 @@ namespace CautionaryAlertsListener.UseCase
                                                 .ConfigureAwait(false);
             if (tenure is null) throw new EntityNotFoundException<TenureInformation>(message.EntityId);
 
-            var newAlerts = new List<PropertyAlertNew>();
-            foreach (var alert in cautionaryAlerts)
-            {
-                var newAlert = new PropertyAlertNew
-                {
-                    Address = tenure.TenuredAsset.FullAddress,
-                    UPRN = tenure.TenuredAsset.Uprn,
-                    PropertyReference = tenure.TenuredAsset.PropertyReference,
-                    AssureReference = alert.AssureReference,
-                    MMHID = alert.MMHID,
-                    PersonName = alert.PersonName,
-                    Code = alert.Code,
-                    CautionOnSystem = alert.CautionOnSystem,
-                    DateOfIncident = alert.DateOfIncident,
-                    Reason = alert.Reason
-                }; // copy cautionary alert to new property
-                newAlerts.Add(newAlert);
-            }
-            await _gateway.SaveEntitiesAsync(newAlerts).ConfigureAwait(false);
+            var alert = cautionaryAlerts.FirstOrDefault();
+            alert.PropertyReference = tenure.TenuredAsset.PropertyReference;
+            alert.UPRN = tenure.TenuredAsset.Uprn;
+            alert.Address = tenure.TenuredAsset.FullAddress;
+
+            await _gateway.UpdateEntityAsync(alert).ConfigureAwait(false);
         }
 
         private static HouseholdMembers GetAddedOrUpdatedHouseholdMember(EntityEventSns message)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -636,5 +636,8 @@ create table dbo."PropertyAlertNew"(
 	"person_name" varchar(100),
 	"mmh_id" varchar(36),
 	"outcome" varchar(100),
-	"assure_reference" varchar(12)
+	"assure_reference" varchar(12),
+	"is_active" Boolean NOT NULL, 
+	"alert_id" varchar(36),
+	"end_date" timestamp
 );


### PR DESCRIPTION
When the AddPersonToTenure event runs it creates a new entity in the postgres db rather than updating the original record to have the new address details. This PR changes the method to update the existing record and have the latest cautionary alerts shared package. 